### PR TITLE
Refactoring of one-shot events

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -143,9 +143,6 @@ dependencies {
     implementation(libs.androidx.navigation.compose)
 
     implementation(libs.mediafile)
-
-    // TODO replace with own implementation
-    implementation(libs.liveevent)
 }
 
 detekt {

--- a/app/src/main/java/com/javernaut/whatthecodec/compose/playground/ComposePlaygroundActivity.kt
+++ b/app/src/main/java/com/javernaut/whatthecodec/compose/playground/ComposePlaygroundActivity.kt
@@ -4,13 +4,29 @@ import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
-import androidx.navigation.compose.NavHost
-import androidx.navigation.compose.composable
-import androidx.navigation.compose.rememberNavController
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.javernaut.whatthecodec.R
 import com.javernaut.whatthecodec.compose.theme.WhatTheCodecTheme
-import com.javernaut.whatthecodec.home.ui.screen.EmptyHomeScreen
-import com.javernaut.whatthecodec.settings.ui.SettingsScreen
-import kotlinx.coroutines.flow.emptyFlow
+import com.javernaut.whatthecodec.home.ui.screen.ObserveAsEvents
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
 
 class ComposePlaygroundActivity : AppCompatActivity() {
 
@@ -20,24 +36,68 @@ class ComposePlaygroundActivity : AppCompatActivity() {
 
         setContent {
             WhatTheCodecTheme {
-                val navController = rememberNavController()
-                NavHost(navController = navController, startDestination = "home") {
-                    composable("home") {
-                        EmptyHomeScreen(
-                            onVideoIconClick = {},
-                            onAudioIconClick = {},
-                            onSettingsClicked = {
-                                navController.navigate("settings")
-                            },
-                            emptyFlow()
-                        )
-                    }
-                    composable("settings") {
-                        SettingsScreen {
-                            navController.popBackStack()
-                        }
-                    }
+                PlaygroundScreen()
+            }
+        }
+    }
+}
+
+class PlaygroundViewModel : ViewModel() {
+
+    private val _screenMessageChannel = Channel<PlaygroundScreenMessage>()
+    val screenMessage = _screenMessageChannel.receiveAsFlow()
+
+//    private val _screenMessage =
+//        MutableStateFlow<PlaygroundScreenMessage>(PlaygroundScreenMessage.NoMessage)
+//    val screenMessage = _screenMessage.asStateFlow()
+
+    fun doSomething() {
+        viewModelScope.launch {
+            _screenMessageChannel.send(PlaygroundScreenMessage.FileOpeningError)
+        }
+    }
+
+//    fun resetMessage() {
+//        viewModelScope.launch {
+//            _screenMessage.value = PlaygroundScreenMessage.NoMessage
+//        }
+//    }
+}
+
+sealed interface PlaygroundScreenMessage {
+    data object FileOpeningError : PlaygroundScreenMessage
+//    data object NoMessage : PlaygroundScreenMessage
+}
+
+@Composable
+private fun PlaygroundScreen(viewModel: PlaygroundViewModel = viewModel()) {
+    val snackbarHostState = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
+
+    val context = LocalContext.current
+    ObserveAsEvents(flow = viewModel.screenMessage) {
+        when (it) {
+            PlaygroundScreenMessage.FileOpeningError -> {
+                scope.launch {
+                    snackbarHostState.showSnackbar(context.getString(R.string.message_couldnt_open_file))
                 }
+            }
+        }
+    }
+
+    Scaffold(
+        snackbarHost = {
+            SnackbarHost(hostState = snackbarHostState)
+        }
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(it),
+            contentAlignment = Alignment.Center
+        ) {
+            Button(onClick = viewModel::doSomething) {
+                Text(text = "Do something")
             }
         }
     }

--- a/app/src/main/java/com/javernaut/whatthecodec/compose/playground/ComposePlaygroundActivity.kt
+++ b/app/src/main/java/com/javernaut/whatthecodec/compose/playground/ComposePlaygroundActivity.kt
@@ -47,26 +47,15 @@ class PlaygroundViewModel : ViewModel() {
     private val _screenMessageChannel = Channel<PlaygroundScreenMessage>()
     val screenMessage = _screenMessageChannel.receiveAsFlow()
 
-//    private val _screenMessage =
-//        MutableStateFlow<PlaygroundScreenMessage>(PlaygroundScreenMessage.NoMessage)
-//    val screenMessage = _screenMessage.asStateFlow()
-
     fun doSomething() {
         viewModelScope.launch {
             _screenMessageChannel.send(PlaygroundScreenMessage.FileOpeningError)
         }
     }
-
-//    fun resetMessage() {
-//        viewModelScope.launch {
-//            _screenMessage.value = PlaygroundScreenMessage.NoMessage
-//        }
-//    }
 }
 
 sealed interface PlaygroundScreenMessage {
     data object FileOpeningError : PlaygroundScreenMessage
-//    data object NoMessage : PlaygroundScreenMessage
 }
 
 @Composable

--- a/app/src/main/java/com/javernaut/whatthecodec/compose/playground/ComposePlaygroundActivity.kt
+++ b/app/src/main/java/com/javernaut/whatthecodec/compose/playground/ComposePlaygroundActivity.kt
@@ -10,6 +10,7 @@ import androidx.navigation.compose.rememberNavController
 import com.javernaut.whatthecodec.compose.theme.WhatTheCodecTheme
 import com.javernaut.whatthecodec.home.ui.screen.EmptyHomeScreen
 import com.javernaut.whatthecodec.settings.ui.SettingsScreen
+import kotlinx.coroutines.flow.emptyFlow
 
 class ComposePlaygroundActivity : AppCompatActivity() {
 
@@ -27,7 +28,8 @@ class ComposePlaygroundActivity : AppCompatActivity() {
                             onAudioIconClick = {},
                             onSettingsClicked = {
                                 navController.navigate("settings")
-                            }
+                            },
+                            emptyFlow()
                         )
                     }
                     composable("settings") {

--- a/app/src/main/java/com/javernaut/whatthecodec/home/presentation/Clipboard.kt
+++ b/app/src/main/java/com/javernaut/whatthecodec/home/presentation/Clipboard.kt
@@ -1,0 +1,22 @@
+package com.javernaut.whatthecodec.home.presentation
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import androidx.core.content.getSystemService
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class Clipboard @Inject constructor(
+    @ApplicationContext context: Context
+) {
+    private val clipboardManager = context.getSystemService<ClipboardManager>()!!
+
+    fun copy(value: String) {
+        clipboardManager.setPrimaryClip(
+            ClipData.newPlainText(null, value)
+        )
+    }
+}

--- a/app/src/main/java/com/javernaut/whatthecodec/home/presentation/MediaFileViewModel.kt
+++ b/app/src/main/java/com/javernaut/whatthecodec/home/presentation/MediaFileViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.hadilq.liveevent.LiveEvent
 import com.javernaut.whatthecodec.home.presentation.model.AvailableTab
 import com.javernaut.whatthecodec.home.presentation.model.BasicVideoInfo
 import com.javernaut.whatthecodec.home.presentation.model.FrameMetrics
@@ -16,6 +15,9 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import io.github.javernaut.mediafile.AudioStream
 import io.github.javernaut.mediafile.MediaFile
 import io.github.javernaut.mediafile.SubtitleStream
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
@@ -31,7 +33,7 @@ class MediaFileViewModel @Inject constructor(
     private var frameLoaderHelper: FrameLoaderHelper? = null
 
     private val _screenState = MutableLiveData<ScreenState?>()
-    private val _errorMessageLiveEvent = LiveEvent<Boolean>()
+    private val _screenMessageChannel = Channel<ScreenMessage>()
 
     init {
         pendingMediaFileArgument = savedStateHandle[KEY_MEDIA_FILE_ARGUMENT]
@@ -46,8 +48,7 @@ class MediaFileViewModel @Inject constructor(
     /**
      * Notifies about error during opening a file.
      */
-    val errorMessageLiveEvent: LiveData<Boolean>
-        get() = _errorMessageLiveEvent
+    val screenMessage = _screenMessageChannel.receiveAsFlow()
 
     override fun onCleared() {
         if (frameLoaderHelper == null) {
@@ -75,7 +76,9 @@ class MediaFileViewModel @Inject constructor(
             mediaFile = newMediaFile
             applyMediaFile(newMediaFile)
         } else {
-            _errorMessageLiveEvent.value = true
+            viewModelScope.launch {
+                _screenMessageChannel.send(ScreenMessage.FileOpeningError)
+            }
         }
     }
 
@@ -169,4 +172,8 @@ data class ScreenState(
             add(AvailableTab.SUBTITLES)
         }
     }
+}
+
+sealed interface ScreenMessage {
+    data object FileOpeningError : ScreenMessage
 }

--- a/app/src/main/java/com/javernaut/whatthecodec/home/presentation/MediaFileViewModel.kt
+++ b/app/src/main/java/com/javernaut/whatthecodec/home/presentation/MediaFileViewModel.kt
@@ -82,6 +82,12 @@ class MediaFileViewModel @Inject constructor(
         }
     }
 
+    fun onPermissionDenied() {
+        viewModelScope.launch {
+            _screenMessageChannel.send(ScreenMessage.PermissionDeniedError)
+        }
+    }
+
     private fun applyMediaFile(mediaFile: MediaFile) {
         _screenState.value = ScreenState(
             mediaFile.toBasicInfo(),
@@ -176,4 +182,5 @@ data class ScreenState(
 
 sealed interface ScreenMessage {
     data object FileOpeningError : ScreenMessage
+    data object PermissionDeniedError : ScreenMessage
 }

--- a/app/src/main/java/com/javernaut/whatthecodec/home/ui/RootActivity.kt
+++ b/app/src/main/java/com/javernaut/whatthecodec/home/ui/RootActivity.kt
@@ -41,12 +41,6 @@ class RootActivity : AppCompatActivity() {
             }
         }
 
-        mediaFileViewModel.errorMessageLiveEvent.observe(this) {
-            if (it) {
-                toast(R.string.message_couldnt_open_file)
-            }
-        }
-
         intentActionViewConsumed =
             savedInstanceState?.getBoolean(EXTRA_INTENT_ACTION_VIEW_CONSUMED) == true
         if (!intentActionViewConsumed) {
@@ -104,6 +98,7 @@ class RootActivity : AppCompatActivity() {
                         else -> actualPickAudioFile()
                     }
                 } else {
+                    // TODO Migrate to Snackbar
                     toast(R.string.message_permission_denied)
                 }
             }

--- a/app/src/main/java/com/javernaut/whatthecodec/home/ui/RootActivity.kt
+++ b/app/src/main/java/com/javernaut/whatthecodec/home/ui/RootActivity.kt
@@ -3,13 +3,11 @@ package com.javernaut.whatthecodec.home.ui
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
-import android.widget.Toast
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.MimeTypeFilter
-import com.javernaut.whatthecodec.R
 import com.javernaut.whatthecodec.compose.theme.WhatTheCodecTheme
 import com.javernaut.whatthecodec.home.presentation.MediaFileArgument
 import com.javernaut.whatthecodec.home.presentation.MediaFileViewModel
@@ -98,8 +96,7 @@ class RootActivity : AppCompatActivity() {
                         else -> actualPickAudioFile()
                     }
                 } else {
-                    // TODO Migrate to Snackbar
-                    toast(R.string.message_permission_denied)
+                    mediaFileViewModel.onPermissionDenied()
                 }
             }
 
@@ -172,10 +169,6 @@ class RootActivity : AppCompatActivity() {
 
     private fun openMediaFile(uri: Uri, mediaType: MediaType) {
         mediaFileViewModel.openMediaFile(MediaFileArgument(uri.toString(), mediaType))
-    }
-
-    private fun toast(msg: Int) {
-        Toast.makeText(this, msg, Toast.LENGTH_LONG).show()
     }
 
     companion object {

--- a/app/src/main/java/com/javernaut/whatthecodec/home/ui/audio/AudioPage.kt
+++ b/app/src/main/java/com/javernaut/whatthecodec/home/ui/audio/AudioPage.kt
@@ -20,16 +20,18 @@ import io.github.javernaut.mediafile.displayable.toDisplayable
 fun AudioPage(
     streams: List<AudioStream>,
     contentPadding: PaddingValues,
+    onCopyValue: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
     SimplePage(streams, contentPadding, modifier) { item, itemModifier ->
-        AudioCardContent(item, itemModifier)
+        AudioCardContent(item, onCopyValue, itemModifier)
     }
 }
 
 @Composable
 private fun AudioCardContent(
     stream: AudioStream,
+    onCopyValue: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val streamFeatures = getFilteredStreamFeatures(
@@ -41,6 +43,7 @@ private fun AudioCardContent(
     StreamFeaturesGrid(
         stream,
         streamFeatures,
+        onCopyValue,
         modifier
     )
 }

--- a/app/src/main/java/com/javernaut/whatthecodec/home/ui/screen/EmptyHomeScreen.kt
+++ b/app/src/main/java/com/javernaut/whatthecodec/home/ui/screen/EmptyHomeScreen.kt
@@ -142,12 +142,18 @@ fun ObserveScreenMessages(
     ObserveAsEvents(screenMassages) {
         scope.launch {
             snackbarHostState.showSnackbar(
-                resources.getString(
-                    when (it) {
-                        ScreenMessage.FileOpeningError -> R.string.message_couldnt_open_file
-                        ScreenMessage.PermissionDeniedError -> R.string.message_permission_denied
-                    }
-                )
+                when (it) {
+                    ScreenMessage.FileOpeningError ->
+                        resources.getString(R.string.message_couldnt_open_file)
+
+                    ScreenMessage.PermissionDeniedError ->
+                        resources.getString(R.string.message_permission_denied)
+
+                    is ScreenMessage.ValueCopied ->
+                        resources.getString(
+                            R.string.stream_text_copied_pattern, it.value
+                        )
+                }
             )
         }
     }

--- a/app/src/main/java/com/javernaut/whatthecodec/home/ui/screen/EmptyHomeScreen.kt
+++ b/app/src/main/java/com/javernaut/whatthecodec/home/ui/screen/EmptyHomeScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.PreviewLightDark
@@ -41,18 +42,13 @@ fun EmptyHomeScreen(
     onSettingsClicked: () -> Unit,
     screenMassages: Flow<ScreenMessage>
 ) {
-    val scope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
-    ObserveAsEvents(screenMassages) {
-        when (it) {
-            ScreenMessage.FileOpeningError -> {
-                scope.launch {
-                    // TODO Read the value from resources
-                    snackbarHostState.showSnackbar("Couldn't open the file")
-                }
-            }
-        }
-    }
+
+    ObserveScreenMessages(
+        screenMassages = screenMassages,
+        snackbarHostState = snackbarHostState
+    )
+
     Scaffold(
         snackbarHost = {
             SnackbarHost(hostState = snackbarHostState)
@@ -133,6 +129,27 @@ private fun EmptyScreenMainAction(
         icon = { Icon(image, null) },
         text = { Text(text = stringResource(id = text)) },
     )
+}
+
+@Composable
+fun ObserveScreenMessages(
+    screenMassages: Flow<ScreenMessage>,
+    snackbarHostState: SnackbarHostState
+) {
+    val scope = rememberCoroutineScope()
+    val resources = LocalContext.current.resources
+
+    ObserveAsEvents(screenMassages) {
+        scope.launch {
+            snackbarHostState.showSnackbar(
+                resources.getString(
+                    when (it) {
+                        ScreenMessage.FileOpeningError -> R.string.message_couldnt_open_file
+                    }
+                )
+            )
+        }
+    }
 }
 
 @PreviewLightDark

--- a/app/src/main/java/com/javernaut/whatthecodec/home/ui/screen/EmptyHomeScreen.kt
+++ b/app/src/main/java/com/javernaut/whatthecodec/home/ui/screen/EmptyHomeScreen.kt
@@ -145,6 +145,7 @@ fun ObserveScreenMessages(
                 resources.getString(
                     when (it) {
                         ScreenMessage.FileOpeningError -> R.string.message_couldnt_open_file
+                        ScreenMessage.PermissionDeniedError -> R.string.message_permission_denied
                     }
                 )
             )

--- a/app/src/main/java/com/javernaut/whatthecodec/home/ui/screen/EmptyHomeScreen.kt
+++ b/app/src/main/java/com/javernaut/whatthecodec/home/ui/screen/EmptyHomeScreen.kt
@@ -13,9 +13,13 @@ import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -25,14 +29,34 @@ import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.javernaut.whatthecodec.R
 import com.javernaut.whatthecodec.compose.theme.WhatTheCodecTheme
+import com.javernaut.whatthecodec.home.presentation.ScreenMessage
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.launch
 
 @Composable
 fun EmptyHomeScreen(
     onVideoIconClick: () -> Unit,
     onAudioIconClick: () -> Unit,
-    onSettingsClicked: () -> Unit
+    onSettingsClicked: () -> Unit,
+    screenMassages: Flow<ScreenMessage>
 ) {
+    val scope = rememberCoroutineScope()
+    val snackbarHostState = remember { SnackbarHostState() }
+    ObserveAsEvents(screenMassages) {
+        when (it) {
+            ScreenMessage.FileOpeningError -> {
+                scope.launch {
+                    // TODO Read the value from resources
+                    snackbarHostState.showSnackbar("Couldn't open the file")
+                }
+            }
+        }
+    }
     Scaffold(
+        snackbarHost = {
+            SnackbarHost(hostState = snackbarHostState)
+        },
         topBar = {
             EmptyScreenTopAppBar(onSettingsClicked)
         }
@@ -115,6 +139,6 @@ private fun EmptyScreenMainAction(
 @Composable
 private fun EmptyScreenPreview() {
     WhatTheCodecTheme {
-        EmptyHomeScreen({}, {}, {})
+        EmptyHomeScreen({}, {}, {}, emptyFlow())
     }
 }

--- a/app/src/main/java/com/javernaut/whatthecodec/home/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/com/javernaut/whatthecodec/home/ui/screen/HomeScreen.kt
@@ -40,6 +40,7 @@ fun HomeScreen(
             onVideoIconClick,
             onAudioIconClick,
             onSettingsClicked,
+            viewModel::copyToClipboard,
             viewModel.screenMessage
         )
     }

--- a/app/src/main/java/com/javernaut/whatthecodec/home/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/com/javernaut/whatthecodec/home/ui/screen/HomeScreen.kt
@@ -5,12 +5,19 @@ import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.res.stringResource
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.repeatOnLifecycle
 import com.javernaut.whatthecodec.R
 import com.javernaut.whatthecodec.home.presentation.MediaFileViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.withContext
 
 @Composable
 fun HomeScreen(
@@ -24,7 +31,8 @@ fun HomeScreen(
         EmptyHomeScreen(
             onVideoIconClick,
             onAudioIconClick,
-            onSettingsClicked
+            onSettingsClicked,
+            viewModel.screenMessage
         )
     } else {
         MainHomeScreen(
@@ -49,5 +57,17 @@ fun HomeScreenSettingsAction(
             imageVector = Icons.Filled.Settings,
             contentDescription = stringResource(id = R.string.menu_settings),
         )
+    }
+}
+
+@Composable
+fun <T> ObserveAsEvents(flow: Flow<T>, onEvent: (T) -> Unit) {
+    val lifecycleOwner = LocalLifecycleOwner.current
+    LaunchedEffect(flow, lifecycleOwner.lifecycle) {
+        lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            withContext(Dispatchers.Main.immediate) {
+                flow.collect(onEvent)
+            }
+        }
     }
 }

--- a/app/src/main/java/com/javernaut/whatthecodec/home/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/com/javernaut/whatthecodec/home/ui/screen/HomeScreen.kt
@@ -39,7 +39,8 @@ fun HomeScreen(
             screenState!!,
             onVideoIconClick,
             onAudioIconClick,
-            onSettingsClicked
+            onSettingsClicked,
+            viewModel.screenMessage
         )
     }
 }

--- a/app/src/main/java/com/javernaut/whatthecodec/home/ui/screen/MainHomeScreen.kt
+++ b/app/src/main/java/com/javernaut/whatthecodec/home/ui/screen/MainHomeScreen.kt
@@ -33,11 +33,14 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SmallFloatingActionButton
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -46,11 +49,13 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.javernaut.whatthecodec.R
 import com.javernaut.whatthecodec.compose.common.OrientationLayout
+import com.javernaut.whatthecodec.home.presentation.ScreenMessage
 import com.javernaut.whatthecodec.home.presentation.ScreenState
 import com.javernaut.whatthecodec.home.presentation.model.AvailableTab
 import com.javernaut.whatthecodec.home.ui.audio.AudioPage
 import com.javernaut.whatthecodec.home.ui.subtitle.SubtitlePage
 import com.javernaut.whatthecodec.home.ui.video.VideoPage
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 
 @Composable
@@ -58,7 +63,8 @@ fun MainHomeScreen(
     screenState: ScreenState,
     onVideoIconClick: () -> Unit,
     onAudioIconClick: () -> Unit,
-    onSettingsClicked: () -> Unit
+    onSettingsClicked: () -> Unit,
+    screenMessage: Flow<ScreenMessage>
 ) {
     OrientationLayout(
         portraitContent = {
@@ -66,7 +72,8 @@ fun MainHomeScreen(
                 screenState,
                 onVideoIconClick,
                 onAudioIconClick,
-                onSettingsClicked
+                onSettingsClicked,
+                screenMessage
             )
         },
         landscapeContent = {
@@ -74,7 +81,8 @@ fun MainHomeScreen(
                 screenState,
                 onVideoIconClick,
                 onAudioIconClick,
-                onSettingsClicked
+                onSettingsClicked,
+                screenMessage
             )
         }
     )
@@ -86,7 +94,8 @@ fun LandscapeMainScreen(
     screenState: ScreenState,
     onVideoIconClick: () -> Unit,
     onAudioIconClick: () -> Unit,
-    onSettingsClicked: () -> Unit
+    onSettingsClicked: () -> Unit,
+    screenMessage: Flow<ScreenMessage>
 ) {
     val tabsToShow = screenState.availableTabs
     val pagerState = rememberPagerState {
@@ -97,10 +106,21 @@ fun LandscapeMainScreen(
         MainScreenSideBar(
             onVideoIconClick, onAudioIconClick, onSettingsClicked
         )
+
+        val snackbarHostState = remember { SnackbarHostState() }
+
+        ObserveScreenMessages(
+            screenMassages = screenMessage,
+            snackbarHostState = snackbarHostState
+        )
+
         Scaffold(
             modifier = Modifier.consumeWindowInsets(
                 WindowInsets.systemBars.only(WindowInsetsSides.Start)
             ),
+            snackbarHost = {
+                SnackbarHost(hostState = snackbarHostState)
+            },
             topBar = {
                 MainScreenTopAppBar(
                     tabsToShow = tabsToShow,
@@ -164,14 +184,25 @@ fun PortraitMainScreen(
     screenState: ScreenState,
     onVideoIconClick: () -> Unit,
     onAudioIconClick: () -> Unit,
-    onSettingsClicked: () -> Unit
+    onSettingsClicked: () -> Unit,
+    screenMessage: Flow<ScreenMessage>
 ) {
     val tabsToShow = screenState.availableTabs
     val pagerState = rememberPagerState {
         tabsToShow.size
     }
 
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    ObserveScreenMessages(
+        screenMassages = screenMessage,
+        snackbarHostState = snackbarHostState
+    )
+
     Scaffold(
+        snackbarHost = {
+            SnackbarHost(hostState = snackbarHostState)
+        },
         bottomBar = {
             MainScreenBottomAppBar(onSettingsClicked, onVideoIconClick, onAudioIconClick)
         },

--- a/app/src/main/java/com/javernaut/whatthecodec/home/ui/screen/MainHomeScreen.kt
+++ b/app/src/main/java/com/javernaut/whatthecodec/home/ui/screen/MainHomeScreen.kt
@@ -64,6 +64,7 @@ fun MainHomeScreen(
     onVideoIconClick: () -> Unit,
     onAudioIconClick: () -> Unit,
     onSettingsClicked: () -> Unit,
+    onCopyValue: (String) -> Unit,
     screenMessage: Flow<ScreenMessage>
 ) {
     OrientationLayout(
@@ -73,6 +74,7 @@ fun MainHomeScreen(
                 onVideoIconClick,
                 onAudioIconClick,
                 onSettingsClicked,
+                onCopyValue,
                 screenMessage
             )
         },
@@ -82,6 +84,7 @@ fun MainHomeScreen(
                 onVideoIconClick,
                 onAudioIconClick,
                 onSettingsClicked,
+                onCopyValue,
                 screenMessage
             )
         }
@@ -95,6 +98,7 @@ fun LandscapeMainScreen(
     onVideoIconClick: () -> Unit,
     onAudioIconClick: () -> Unit,
     onSettingsClicked: () -> Unit,
+    onCopyValue: (String) -> Unit,
     screenMessage: Flow<ScreenMessage>
 ) {
     val tabsToShow = screenState.availableTabs
@@ -133,6 +137,7 @@ fun LandscapeMainScreen(
                 screenState = screenState,
                 pagerState = pagerState,
                 contentPadding = it,
+                onCopyValue = onCopyValue,
                 modifier = Modifier
                     .fillMaxSize()
             )
@@ -185,6 +190,7 @@ fun PortraitMainScreen(
     onVideoIconClick: () -> Unit,
     onAudioIconClick: () -> Unit,
     onSettingsClicked: () -> Unit,
+    onCopyValue: (String) -> Unit,
     screenMessage: Flow<ScreenMessage>
 ) {
     val tabsToShow = screenState.availableTabs
@@ -218,6 +224,7 @@ fun PortraitMainScreen(
             screenState = screenState,
             pagerState = pagerState,
             contentPadding = it,
+            onCopyValue = onCopyValue,
             modifier = Modifier.fillMaxSize()
         )
     }
@@ -293,20 +300,22 @@ private fun MainScreenContent(
     screenState: ScreenState,
     pagerState: PagerState,
     contentPadding: PaddingValues,
+    onCopyValue: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val pageModifier = Modifier.fillMaxSize()
     HorizontalPager(pagerState, modifier) { page ->
         when (screenState.availableTabs[page]) {
             AvailableTab.VIDEO ->
-                VideoPage(screenState.videoPage!!, contentPadding, pageModifier)
+                VideoPage(screenState.videoPage!!, contentPadding, onCopyValue, pageModifier)
 
             AvailableTab.AUDIO ->
-                AudioPage(screenState.audioPage!!, contentPadding, pageModifier)
+                AudioPage(screenState.audioPage!!, contentPadding, onCopyValue, pageModifier)
 
             AvailableTab.SUBTITLES -> SubtitlePage(
                 screenState.subtitlesPage!!,
                 contentPadding,
+                onCopyValue,
                 pageModifier
             )
         }

--- a/app/src/main/java/com/javernaut/whatthecodec/home/ui/stream/StreamCard.kt
+++ b/app/src/main/java/com/javernaut/whatthecodec/home/ui/stream/StreamCard.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement.spacedBy
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.calculateEndPadding
@@ -94,11 +93,11 @@ fun <T : MediaStream> SimplePage(
     }
 }
 
-@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun <T : MediaStream> StreamFeaturesGrid(
     stream: T,
     features: List<StreamFeature<T>>,
+    onCopyValue: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val resources = LocalContext.current.resources
@@ -112,7 +111,7 @@ fun <T : MediaStream> StreamFeaturesGrid(
             columns = 2
         ) {
             displayableFeatures.forEach {
-                StreamFeatureItem(stream, it, Modifier.fillMaxWidth())
+                StreamFeatureItem(stream, it, onCopyValue, Modifier.fillMaxWidth())
             }
         }
     } else {

--- a/app/src/main/java/com/javernaut/whatthecodec/home/ui/stream/StreamFeatureItem.kt
+++ b/app/src/main/java/com/javernaut/whatthecodec/home/ui/stream/StreamFeatureItem.kt
@@ -1,9 +1,5 @@
 package com.javernaut.whatthecodec.home.ui.stream
 
-import android.content.ClipData
-import android.content.ClipboardManager
-import android.content.Context
-import android.widget.Toast
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement.spacedBy
@@ -26,7 +22,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
-import androidx.core.content.getSystemService
 import com.javernaut.whatthecodec.R
 import com.javernaut.whatthecodec.compose.theme.WhatTheCodecTheme
 import io.github.javernaut.mediafile.MediaStream
@@ -35,20 +30,23 @@ import io.github.javernaut.mediafile.MediaStream
 fun StreamFeatureItem(
     title: String,
     value: String,
+    onCopyValue: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Box(modifier = modifier) {
         var expanded by remember { mutableStateOf(false) }
-        StreamFeature(title, value) {
+        StreamFeature(
+            title = title,
+            value = value
+        ) {
             expanded = true
         }
-        val context = LocalContext.current
         CopyToClipboardDropdown(
-            expanded,
-            value,
-            { expanded = false }
+            expanded = expanded,
+            title = value,
+            dismissCallback = { expanded = false }
         ) {
-            copyTextToClipboard(context, value)
+            onCopyValue(value)
         }
     }
 }
@@ -57,26 +55,17 @@ fun StreamFeatureItem(
 fun <T : MediaStream> StreamFeatureItem(
     stream: T,
     streamFeature: StreamFeature<T>,
+    onCopyValue: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
     streamFeature.getValue(stream, LocalContext.current.resources)?.let { value ->
         StreamFeatureItem(
             stringResource(id = streamFeature.title),
             value,
+            onCopyValue,
             modifier
         )
     }
-}
-
-private fun copyTextToClipboard(context: Context, valueToCopy: String) {
-    val clipboardManager = context.getSystemService<ClipboardManager>()!!
-    clipboardManager.setPrimaryClip(
-        ClipData.newPlainText(valueToCopy, valueToCopy)
-    )
-    val toastMessage = context.getString(
-        R.string.stream_text_copied_pattern, valueToCopy
-    )
-    Toast.makeText(context, toastMessage, Toast.LENGTH_SHORT).show()
 }
 
 @PreviewLightDark

--- a/app/src/main/java/com/javernaut/whatthecodec/home/ui/subtitle/SubtitlePage.kt
+++ b/app/src/main/java/com/javernaut/whatthecodec/home/ui/subtitle/SubtitlePage.kt
@@ -19,16 +19,18 @@ import io.github.javernaut.mediafile.displayable.getDisplayableDisposition
 fun SubtitlePage(
     streams: List<SubtitleStream>,
     contentPadding: PaddingValues,
+    onCopyValue: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
     SimplePage(streams, contentPadding, modifier) { item, itemModifier ->
-        SubtitleCardContent(item, itemModifier)
+        SubtitleCardContent(item, onCopyValue, itemModifier)
     }
 }
 
 @Composable
 private fun SubtitleCardContent(
     stream: SubtitleStream,
+    onCopyValue: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val streamFeatures = getFilteredStreamFeatures(
@@ -40,6 +42,7 @@ private fun SubtitleCardContent(
     StreamFeaturesGrid(
         stream,
         streamFeatures,
+        onCopyValue,
         modifier
     )
 }

--- a/app/src/main/java/com/javernaut/whatthecodec/home/ui/video/VideoPage.kt
+++ b/app/src/main/java/com/javernaut/whatthecodec/home/ui/video/VideoPage.kt
@@ -29,6 +29,7 @@ import io.github.javernaut.mediafile.displayable.toDisplayable
 fun VideoPage(
     videoInfo: BasicVideoInfo,
     contentPadding: PaddingValues,
+    onCopyValue: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
     LazyColumn(
@@ -42,6 +43,7 @@ fun VideoPage(
         item {
             Container(
                 basicVideoInfo = videoInfo,
+                onCopyValue = onCopyValue,
                 modifier = commonModifier
                     .padding(top = 16.dp)
             )
@@ -49,6 +51,7 @@ fun VideoPage(
         item {
             VideoStream(
                 videoStream = videoInfo.videoStream,
+                onCopyValue = onCopyValue,
                 modifier = commonModifier.padding(vertical = 16.dp)
             )
         }
@@ -58,6 +61,7 @@ fun VideoPage(
 @Composable
 private fun Container(
     basicVideoInfo: BasicVideoInfo,
+    onCopyValue: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
     StreamCard(
@@ -68,6 +72,7 @@ private fun Container(
             StreamFeatureItem(
                 title = stringResource(id = R.string.info_file_format),
                 value = basicVideoInfo.fileFormat,
+                onCopyValue = onCopyValue,
                 modifier = Modifier.weight(1f)
             )
             StreamFeatureItem(
@@ -79,6 +84,7 @@ private fun Container(
                         R.string.info_protocol_pipe
                     }
                 ),
+                onCopyValue = onCopyValue,
                 modifier = Modifier.weight(1f)
             )
         }
@@ -88,6 +94,7 @@ private fun Container(
 @Composable
 private fun VideoStream(
     videoStream: VideoStream,
+    onCopyValue: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
     StreamCard(
@@ -103,6 +110,7 @@ private fun VideoStream(
         StreamFeaturesGrid(
             stream = videoStream,
             features = streamFeatures,
+            onCopyValue = onCopyValue,
             modifier = it
         )
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,6 @@ detekt = "1.23.6"
 
 [libraries]
 mediafile = "io.github.javernaut:mediafile:1.1.0"
-liveevent = "com.github.hadilq.liveevent:liveevent:1.2.0"
 
 coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinx-coroutines" }


### PR DESCRIPTION
Main things that were done:

- Consolidating all toast messages into a single source - the MediaFileViewModel
- Removing old 'one shot event' solution's dependency
- Replacing all Toast messages with Snackbars